### PR TITLE
[fix] Remove tokens by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,26 +176,6 @@ protected function getSocialiteUser(Request $request, string $provider)
 }
 ```
 
-For example, wanting to generate the redirect and get the user within an API can be done:
-
-```php
-protected function getSocialiteRedirect(Request $request, string $provider)
-{
-    return $this->socialite
-        ->driver($provider)
-        ->stateless()
-        ->redirect();
-}
-
-protected function getSocialiteUser(Request $request, string $provider)
-{
-    return $this->socialite
-        ->driver($provider)
-        ->stateless()
-        ->user();
-}
-```
-
 ## Link & Unlink
 
 Prior to creating new accounts or logging in with Socialite providers, Hej! comes with support to link and unlink Social accounts to and from your users.

--- a/README.md
+++ b/README.md
@@ -437,11 +437,6 @@ protected function getSocialData(Request $request, string $provider, $model, $pr
         'provider_name' => $providerUser->getName(),
         'provider_email' => $providerUser->getEmail(),
         'provider_avatar' => $providerUser->getAvatar(),
-        'token' => $providerUser->token,
-        'token_secret' => $providerUser->tokenSecret ?? null,
-        'refresh_token' => $providerUser->refreshToken ?? null,
-        'token_expires_at' => isset($providerUser->expiresIn) ? now()->addSeconds($providerUser->expiresIn) : null,
-        'provider_data' => $providerUser->getRaw(),
     ];
 }
 ```

--- a/database/migrations/2020_07_24_000000_create_socials_table.php
+++ b/database/migrations/2020_07_24_000000_create_socials_table.php
@@ -22,11 +22,6 @@ class CreateSocialsTable extends Migration
             $table->string('provider_name')->nullable();
             $table->string('provider_email')->nullable();
             $table->string('provider_avatar')->nullable();
-            $table->json('provider_data')->nullable();
-            $table->string('token')->nullable();
-            $table->string('token_secret')->nullable();
-            $table->string('refresh_token')->nullable();
-            $table->timestamp('token_expires_at')->nullable();
             $table->timestamps();
 
             $table->index(['model_id', 'model_type']);

--- a/src/Http/Controllers/SocialController.php
+++ b/src/Http/Controllers/SocialController.php
@@ -103,7 +103,6 @@ class SocialController extends Controller
         return [
             'name' => $providerUser->getName(),
             'email' => $providerUser->getEmail(),
-            'email_verified_at' => now(),
             'password' => Hash::make(Str::random(64)),
         ];
     }
@@ -124,11 +123,6 @@ class SocialController extends Controller
             'provider_name' => $providerUser->getName(),
             'provider_email' => $providerUser->getEmail(),
             'provider_avatar' => $providerUser->getAvatar(),
-            'token' => $providerUser->token,
-            'token_secret' => $providerUser->tokenSecret ?? null,
-            'refresh_token' => $providerUser->refreshToken ?? null,
-            'token_expires_at' => isset($providerUser->expiresIn) ? now()->addSeconds($providerUser->expiresIn) : null,
-            'provider_data' => $providerUser->getRaw(),
         ];
     }
 

--- a/src/Social.php
+++ b/src/Social.php
@@ -12,24 +12,7 @@ class Social extends Model
     protected $fillable = [
         'model_id', 'model_type', 'provider', 'provider_id',
         'provider_nickname', 'provider_name', 'provider_email',
-        'provider_avatar', 'token', 'token_secret', 'refresh_token',
-        'token_expires_at', 'provider_data',
-    ];
-
-    /**
-     * {@inheritdoc}
-     */
-    protected $hidden = [
-        'token', 'token_secret',
-        'refresh_token', 'token_expires_at',
-        'provider_data',
-    ];
-
-    /**
-     * {@inheritdoc}
-     */
-    protected $dates = [
-        'token_expires_at',
+        'provider_avatar',
     ];
 
     /**

--- a/tests/ProviderTest.php
+++ b/tests/ProviderTest.php
@@ -58,18 +58,6 @@ class ProviderTest extends TestCase
             'provider_name' => 'rennokki',
             'provider_email' => 'test@test.com',
             'provider_avatar' => 'https://avatars2.githubusercontent.com/u/21983456?v=4',
-            'provider_data' => [
-                'login' => 'rennokki',
-                'id' => 1234,
-                'avatar_url' => 'https://avatars2.githubusercontent.com/u/21983456?v=4',
-                'url' => 'https://api.github.com/users/rennokki',
-                'email' => 'test@test.com',
-                'name' => 'rennokki',
-            ],
-            'token' => 'token_123',
-            'token_secret' => null,
-            'refresh_token' => null,
-            'token_expires_at' => null,
         ];
 
         $existingData = $social->setHidden([])->toArray();
@@ -115,18 +103,6 @@ class ProviderTest extends TestCase
             'provider_name' => 'rennokki',
             'provider_email' => 'test@test.com',
             'provider_avatar' => 'https://avatars2.githubusercontent.com/u/21983456?v=4',
-            'provider_data' => [
-                'login' => 'rennokki',
-                'id' => 1234,
-                'avatar_url' => 'https://avatars2.githubusercontent.com/u/21983456?v=4',
-                'url' => 'https://api.github.com/users/rennokki',
-                'email' => 'test@test.com',
-                'name' => 'rennokki',
-            ],
-            'token' => 'token_123',
-            'token_secret' => null,
-            'refresh_token' => null,
-            'token_expires_at' => null,
         ];
 
         $existingData = $social->setHidden([])->toArray();
@@ -204,18 +180,6 @@ class ProviderTest extends TestCase
             'provider_name' => 'rennokki',
             'provider_email' => 'test@test.com',
             'provider_avatar' => 'https://avatars2.githubusercontent.com/u/21983456?v=4',
-            'provider_data' => [
-                'login' => 'rennokki',
-                'id' => 1234,
-                'avatar_url' => 'https://avatars2.githubusercontent.com/u/21983456?v=4',
-                'url' => 'https://api.github.com/users/rennokki',
-                'email' => 'test@test.com',
-                'name' => 'rennokki',
-            ],
-            'token' => 'token_123',
-            'token_secret' => null,
-            'refresh_token' => null,
-            'token_expires_at' => null,
         ];
 
         $existingData = $social->setHidden([])->toArray();


### PR DESCRIPTION
Laravel Socialite has the main purpose of logging in users, optionally to use the tokens generated by the users.

With this PR, Hej! will not store tokens by default anymore.

Many thanks to this comment: https://www.reddit.com/r/laravel/comments/hyyagg/hej_a_simple_socialite_authentication_flow/fzid6jo/